### PR TITLE
Adds update only flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,12 @@ In the Cloud Shell, execute the following command:
 git clone https://github.com/google/wci && cd wci && sh ./deployment/deploy.sh
 ```
 
+## Updating WCI to the latest version
+In the Cloud Shell, execute the following command:
+``` shell
+git clone https://github.com/google/wci && cd wci && sh ./deployment/deploy.sh service=update
+```
+
 ## Guided Deployment
 If you want to do a guided deployment through Cloud Shell, click the link below:<br>
 [![Open in Cloud Shell](https://gstatic.com/cloudssh/images/open-btn.svg)](https://shell.cloud.google.com/cloudshell/editor?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Fgoogle%2Fwci&cloudshell_git_branch=main&cloudshell_tutorial=tutorial.md)


### PR DESCRIPTION
This PR adds a new flag when deploying WCI. By executing ./deployment/deploy.sh, one is able to inform the following flag and value into order to update their WCI service to the lastest version (without having to redo the entire deployment):

```
sh ./deployment/deploy.sh service=update
```